### PR TITLE
Added method to substitute placeholders in ScenarioOutline name

### DIFF
--- a/src/main/java/com/trivago/rta/gherkin/GherkinDocumentParser.java
+++ b/src/main/java/com/trivago/rta/gherkin/GherkinDocumentParser.java
@@ -37,6 +37,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Singleton
 public class GherkinDocumentParser {
@@ -186,7 +188,7 @@ public class GherkinDocumentParser {
                     new SingleScenario(
                             featureName,
                             featureDescription,
-                            scenarioName,
+                            substituteScenarioNameExamplePlaceholders(scenarioName, exampleMap, i),
                             scenarioDescription,
                             featureTags,
                             backgroundSteps
@@ -352,6 +354,32 @@ public class GherkinDocumentParser {
             }
             return result;
         }
+    }
+
+    /**
+     * Replaces the example value placeholders in ScenarioOutline name by the actual example table values.
+     *
+     * @param scenarioOutlineName      The ScenarioOutline generic name.
+     * @param exampleMap The generated example map from an example table.
+     * @param rowIndex   The row index of the example table to consider.
+     * @return a {@link String} name with placeholders substituted for actual values from example table.
+     */
+
+    private String substituteScenarioNameExamplePlaceholders(
+            final String scenarioOutlineName,
+            final  Map<String, List<String>> exampleMap,
+            final int rowIndex) {
+        String result = scenarioOutlineName;
+        String placeholderPattern = "<.+?>";
+        Pattern p = Pattern.compile(placeholderPattern);
+        Matcher m = p.matcher(scenarioOutlineName);
+
+        while (m.find()) {
+            String currentPlaceholder = m.group(0);
+            result = result.replace(currentPlaceholder, exampleMap.get(currentPlaceholder).get(rowIndex));
+        }
+
+        return result;
     }
 }
 

--- a/src/test/java/com/trivago/rta/gherkin/GherkinDocumentParserTest.java
+++ b/src/test/java/com/trivago/rta/gherkin/GherkinDocumentParserTest.java
@@ -237,6 +237,32 @@ public class GherkinDocumentParserTest {
     }
 
     @Test
+    public void validScenarioNamesWithScenarioOutlineTest() throws Exception {
+        String featureContent = "Feature: test feature 3\n" +
+                "\n" +
+                "  Scenario Outline: This is a scenario outline, key = <key>, value = <value>\n" +
+                "    This is a step\n" +
+                "    How about another step\n" +
+                "\n" +
+                "    Examples:\n" +
+                "      | key | value |\n" +
+                "      | 1   | one   |\n" +
+                "      | 2   | two   |";
+
+        List<SingleScenario> singleScenariosFromFeature = gherkinDocumentParser.getSingleScenariosFromFeature(featureContent, null, null, null);
+        assertThat(singleScenariosFromFeature.size(), is(2));
+
+        SingleScenario scenario = singleScenariosFromFeature.get(0);
+
+        assertThat(scenario.getScenarioName(), is("This is a scenario outline, key = 1, value = one"));
+
+        scenario = singleScenariosFromFeature.get(1);
+
+        assertThat(scenario.getScenarioName(), is("This is a scenario outline, key = 2, value = two"));
+    }
+
+
+    @Test
     public void replaceDataTableExamplePlaceholderTest() throws Exception {
         String featureContent = "Feature: test feature 3\n" +
                 "\n" +


### PR DESCRIPTION
Replacing placeholders in Scenario Outline name, to facilitate handling test outcomes for reporting purposes.